### PR TITLE
store expired keys in db and fix token duration issues

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -27,3 +27,11 @@ ALTER TABLE boards
     ADD COLUMN IF NOT EXISTS public_id varchar(36) NOT NULL,
     ADD COLUMN IF NOT EXISTS private_id varchar(44) NOT NULL,
     ADD COLUMN IF NOT EXISTS board_state json NOT NULL;
+
+-- jwt
+
+CREATE TABLE IF NOT EXISTS expired_jwts (
+	id SERIAL PRIMARY KEY,
+	jwt_data VARCHAR (500) NOT NULL,
+	expire_date DATE NOT NULL DEFAULT CURRENT_DATE
+);

--- a/dev.sh
+++ b/dev.sh
@@ -7,7 +7,8 @@ export DB_HOST=localhost
 export DB_USER=board4you
 export CLEANUP_INTERVAL_MINUTES=1
 export DB_INIT_PATH="${PWD}/db/init.sql"
-export DB_PASSWORD_PATH="${PWD}/secrets/db_password"
+export DB_PASSWORD_PATH="${PWD}/secrets/db_password.txt"
+export JWT_SECRET_PATH="${PWD}/secrets/jwt-secret.txt"
 # rust
 export RUST_BACKTRACE=1
 export RUST_LOG=trace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "80:3000"
     secrets:
       - db_password
+      - jwt_secret
     depends_on:
       db:
         condition: service_healthy
@@ -45,3 +46,5 @@ services:
 secrets:
   db_password:
     file: ./secrets/db_password.txt
+  jwt_secret:
+    file: ./secrets/jwt_secret.txt

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -8,16 +8,16 @@ use room_filter::room_filter;
 use user_filter::user_filter;
 use warp::Filter;
 
-use crate::libs::{state::{DbClient, JwtKey, Rooms}, auth::JwtExpired};
+use crate::libs::state::{DbClient, JwtKey, Rooms};
 
 // exports
 
 pub use common::handle_rejection;
 
-pub fn api(client: DbClient, jwt_key: JwtKey, expired_jwt_tokens: JwtExpired, rooms: Rooms) 
--> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone + '_
+pub fn api(client: DbClient, jwt_key: JwtKey, rooms: Rooms) 
+-> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
 {
-    auth_filter(&client, &jwt_key, expired_jwt_tokens.clone())
-    .or(room_filter(rooms, client.clone(), jwt_key.clone(), expired_jwt_tokens.clone()))
-    .or(user_filter(client, jwt_key, expired_jwt_tokens))
+    auth_filter(&client, &jwt_key)
+    .or(room_filter(rooms, client.clone(), jwt_key.clone()))
+    .or(user_filter(client, jwt_key))
 }

--- a/server/src/entities/jwt.rs
+++ b/server/src/entities/jwt.rs
@@ -1,0 +1,26 @@
+use tokio_postgres::Error;
+
+use crate::libs::state::DbClient;
+
+pub async fn exists(client: &DbClient, token: &str) -> bool{
+    let key_count = client.query_one(
+        "SELECT COUNT(id) FROM expired_jwts WHERE jwt_data=($1)",
+        &[&token]
+    ).await;
+
+    match key_count {
+        Ok(row) => {
+            return row.get::<&str, i64>("count") == 0
+        }
+        Err(_) => {
+            false
+        }
+    }
+}
+
+pub async fn create(client: &DbClient, token: &str) -> Result<u64, Error> {
+    client.execute(
+        "INSERT INTO expired_jwts(jwt_data) VALUES($1)",
+        &[&token]
+    ).await
+}

--- a/server/src/entities/mod.rs
+++ b/server/src/entities/mod.rs
@@ -1,2 +1,3 @@
 pub mod board;
 pub mod user;
+pub mod jwt;


### PR DESCRIPTION
- store expired keys in db
- token now won't be accepted if its duration is invalid
- use same secret key for jwt between app launches